### PR TITLE
Fix for development version of dplyr

### DIFF
--- a/R/polyfill_base_pipe.R
+++ b/R/polyfill_base_pipe.R
@@ -2,7 +2,7 @@
 #'
 #' Rejig the value columnm of sourcetools::tokenize_string(), such that base
 #' pipe is a first class operator - appears in the `value` column as "|>".
-#' 
+#'
 #' This allows all the other infix machinery to handle base pipe as a regular
 #' infix operator.
 #'
@@ -12,17 +12,17 @@ polyfill_base_pipe <- function(source_tokens) {
   vertical_bar <- source_tokens$value == "|"
   greater_than <- source_tokens$value == ">"
   same_row <-
-    source_tokens$row == dplyr::lead(source_tokens$row, 
+    source_tokens$row == dplyr::lead(as.numeric(source_tokens$row),
                                     default = Inf)
-  pipes <- 
-    vertical_bar & 
+  pipes <-
+    vertical_bar &
     dplyr::lead(greater_than, default = FALSE) &
     same_row
 
-  pipe_tails <- 
+  pipe_tails <-
     dplyr::lag(pipes, default = FALSE)
 
-  source_tokens$value[pipes] <- "|>"  
+  source_tokens$value[pipes] <- "|>"
   source_tokens[!pipe_tails, ]
 }
 


### PR DESCRIPTION
The current development version of dplyr breaks the package because it seems stricter about types.  This backwards compatible PR fixes the problem.